### PR TITLE
fix RDFilters.evaluate return value when smiles conversion fails

### DIFF
--- a/rd_filters/rd_filters.py
+++ b/rd_filters/rd_filters.py
@@ -144,7 +144,7 @@ class RDFilters:
         smiles, name = lst_in
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
-            return [smiles, name, 'INVALID', -999, -999, -999, -999, -999]
+            return [smiles, name, 'INVALID', -999, -999, -999, -999, -999, -999]
         desc_list = [MolWt(mol), MolLogP(mol), NumHDonors(mol), NumHAcceptors(mol), TPSA(mol),
                      CalcNumRotatableBonds(mol)]
         for row in self.rule_list:


### PR DESCRIPTION
RDFilters.evalute returns two different lists depending on whether or not the
call to Chem.MolFromSmiles was successful. A successful call will eventually
result in returning a list with nine values, as defined in the assignment to
desc_list, while a failed call would result in returning a list with eight
"placeholder" values. This mismatch of list length would then result in an error
during creation of a Pandas dataframe using the return value with a columns list
having a length of nine.

This fix adds a ninth value to the list returned in the case of a failing call
to Chem.MolFromSmiles, preventing the error in Pandas DataFrame creation.