### PR TITLE
Fix pkg_resources deprecation and add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: CI testing
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, fix-pkg-resources]
   pull_request:
     branches: [master, main]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: CI testing
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, fix-pkg-resources]
   pull_request:
     branches: [master, main]
 
@@ -27,7 +27,6 @@ jobs:
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: CI testing
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  pytester:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Runner images: https://github.com/actions/runner-images
+        os: ["ubuntu-24.04"]
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv and setup python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv pip install -e .
+          uv pip install pytest
+
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: CI testing
 
 on:
   push:
-    branches: [master, main, fix-pkg-resources]
+    branches: [master, main]
   pull_request:
     branches: [master, main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.pytest_cache/
+.coverage
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Environment
+.env

--- a/rd_filters/rd_filters.py
+++ b/rd_filters/rd_filters.py
@@ -11,7 +11,7 @@ import pandas as pd
 import os
 import json
 from docopt import docopt
-import pkg_resources
+from importlib import resources
 
 cmd_str = """Usage:
 rd_filters filter --in INPUT_FILE --prefix PREFIX [--rules RULES_FILE_NAME] [--alerts ALERT_FILE_NAME][--np NUM_CORES]
@@ -156,8 +156,9 @@ class RDFilters:
 
 def main():
     cmd_input = docopt(cmd_str)
-    alert_file_name = cmd_input.get("--alerts") or pkg_resources.resource_filename('rd_filters',
-                                                                                   "data/alert_collection.csv")
+    alert_file_name = cmd_input.get("--alerts") or str(
+        resources.files("rd_filters") / "data" / "alert_collection.csv"
+    )
     rf = RDFilters(alert_file_name)
 
     if cmd_input.get("template"):
@@ -166,7 +167,9 @@ def main():
 
     elif cmd_input.get("filter"):
         input_file_name = cmd_input.get("--in")
-        rules_file_name = cmd_input.get("--rules") or pkg_resources.resource_filename('rd_filters', "data/rules.json")
+        rules_file_name = cmd_input.get("--rules") or str(
+            resources.files("rd_filters") / "data" / "rules.json"
+        )
         rules_file_path = get_config_file(rules_file_name, "FILTER_RULES_DATA")
         prefix_name = cmd_input.get("--prefix")
         num_cores = cmd_input.get("--np") or mp.cpu_count()
@@ -193,7 +196,7 @@ def main():
             df.HBA.between(*rule_dict["HBA"]) &
             df.TPSA.between(*rule_dict["TPSA"]) &
             df.Rot.between(*rule_dict["Rot"])
-            ]
+        ]
         output_smiles_file = prefix_name + ".smi"
         output_csv_file = prefix_name + ".csv"
         df_ok[["SMILES", "NAME"]].to_csv(f"{output_smiles_file}", sep=" ", index=False, header=False)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
             'rd_filters=rd_filters.rd_filters:main',
         ],
     },
-    install_requires=['pandas', 'docopt'],
+    install_requires=['pandas', 'docopt', 'rdkit'],
     include_package_data=True,
 )

--- a/tests/test_rdfilter.py
+++ b/tests/test_rdfilter.py
@@ -1,5 +1,5 @@
 from rd_filters import rd_filters
-import pkg_resources
+from importlib import resources
 
 # these just stop on the first filter
 test_lint = [
@@ -50,10 +50,9 @@ test_inpharmatica = [
     ('NC=NO', 'Filter89_hydroxylamine > 0'),
     ('C(=O)NOS', 'Filter31_so_bond > 0'),
 ]
-         
+
 def test_hydrogen_suppression():
-    alert_file_name = pkg_resources.resource_filename('rd_filters',
-                                                      "data/alert_collection.csv")
+    alert_file_name = str(resources.files("rd_filters") / "data" / "alert_collection.csv")                                                    "data/alert_collection.csv")
     for rule_list, tests in [(["Inpharmatica"], test_inpharmatica),
                              (["LINT"], test_lint)]:
         rf = rd_filters.RDFilters(alert_file_name)

--- a/tests/test_rdfilter.py
+++ b/tests/test_rdfilter.py
@@ -52,7 +52,7 @@ test_inpharmatica = [
 ]
 
 def test_hydrogen_suppression():
-    alert_file_name = str(resources.files("rd_filters") / "data" / "alert_collection.csv")                                                    "data/alert_collection.csv")
+    alert_file_name = str(resources.files("rd_filters") / "data" / "alert_collection.csv")
     for rule_list, tests in [(["Inpharmatica"], test_inpharmatica),
                              (["LINT"], test_lint)]:
         rf = rd_filters.RDFilters(alert_file_name)


### PR DESCRIPTION
## What does this pr do ?

This PR replaces the deprecated `pkg_resources` with `importlib.resources` for file path resolution. 
It also fixes syntax errors, adds the missing `rdkit` dependency, and introduces a minimal CI testing with GitHub Actions.